### PR TITLE
fix build_shaders.sh + replace GL15CMixin with GL15Mixin and include it + differentiate between glBufferDataBB and glBufferDataSize

### DIFF
--- a/src/client/java/com/metalrender/sodium/mixins/lwjgl/GL15Mixin.java
+++ b/src/client/java/com/metalrender/sodium/mixins/lwjgl/GL15Mixin.java
@@ -11,8 +11,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Pseudo
-@Mixin(targets = {"org.lwjgl.opengl.GL15C"})
-public class GL15CMixin {
+@Mixin(targets = {"org.lwjgl.opengl.GL15"}) // the only non-native glBindBuffer is in GL15, not in GL15C
+public class GL15Mixin {
     @Inject(method = {"glBindBuffer"}, at = { @At("HEAD") }, remap = false)
     private static void metalrender$onBindBuffer(int target, int buffer, CallbackInfo ci) {
         if (MetalRenderConfig.mirrorUploads()) {
@@ -20,7 +20,7 @@ public class GL15CMixin {
         }
     }
 
-    @Inject(method = {"glBufferData"}, at = { @At("HEAD") }, remap = false)
+    @Inject(method = {"glBufferData(ILjava/nio/ByteBuffer;I)V"}, at = { @At("HEAD") }, remap = false)
     private static void metalrender$onBufferDataBB(int target, ByteBuffer data, int usage, CallbackInfo ci) {
         if (MetalRenderConfig.mirrorUploads()) {
             GLIntercept.onBufferData(target, data, usage, 32);

--- a/src/main/native/build_shaders.sh
+++ b/src/main/native/build_shaders.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [ ! -d "src/main/resources/native/shaders/compiled" ]
+    mkdir src/main/resources/native/shaders/compiled
+fi
+
 xcrun -sdk macosx metal -o src/main/resources/native/shaders/compiled/fragment.ir -c src/main/resources/native/shaders/fragment.metal
 xcrun -sdk macosx metal -o src/main/resources/native/shaders/compiled/vertex.ir -c src/main/resources/native/shaders/vertex.metal
-xcrun -sdk macosx metallib -o build/native/shaders.metallib src/main/resources/native/shaders/compiled/fragment.ir src/main/resources/native/shaders/compiled/vertex.ir
+xcrun -sdk macosx metal -o src/main/resources/native/shaders/compiled/occlusion_culling.ir -c src/main/resources/native/shaders/occlusion_culling.metal
+
+xcrun -sdk macosx metallib -o build/native/shaders.metallib src/main/resources/native/shaders/compiled/fragment.ir src/main/resources/native/shaders/compiled/vertex.ir src/main/resources/native/shaders/compiled/occlusion_culling.ir
+
 cp build/native/shaders.metallib src/main/resources/

--- a/src/main/resources/metalrender.mixins.json
+++ b/src/main/resources/metalrender.mixins.json
@@ -12,6 +12,7 @@
     "RenderSectionMixin",
     "ScreenAccessor",
     "sodiumhook.SodiumWorldRendererMixin_CM",
-    "lwjgl.GL11CMixin"
+    "lwjgl.GL11CMixin",
+    "lwjgl.GL15Mixin"
   ]
 }


### PR DESCRIPTION
the `glBindBuffer` in GL15C is native, which is probably why it crashes when you include it. glBufferData needed to be differentiated as well to avoid a separate crash.