### PR TITLE
Bump Stable Release 0.1.6 to 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.11-SNAPSHOT'
+    id 'fabric-loom' version '1.14-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -26,17 +26,17 @@ repositories {
         }
 }
 dependencies {
-    minecraft "com.mojang:minecraft:1.21.10"
-    mappings "net.fabricmc:yarn:1.21.10+build.1:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.17.2"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:0.135.0+1.21.10"
+    minecraft "com.mojang:minecraft:1.21.11"
+    mappings "net.fabricmc:yarn:1.21.11+build.3:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.18.0"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:0.139.4+1.21.11"
     modImplementation "org.lwjgl:lwjgl:3.3.3"
     modImplementation "org.lwjgl:lwjgl-glfw:3.3.3"
     modImplementation "org.lwjgl:lwjgl:3.3.3:natives-macos"
     modImplementation "org.lwjgl:lwjgl-glfw:3.3.3:natives-macos"
     modImplementation 'org.joml:joml:1.10.5'
-    modImplementation "maven.modrinth:sodium:mc1.21.10-0.7.2-fabric"
-    modImplementation "maven.modrinth:modmenu:16.0.0-rc.1"
+    modImplementation "maven.modrinth:sodium:mc1.21.11-0.8.0-fabric"
+    modImplementation "maven.modrinth:modmenu:17.0.0-alpha.1"
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version=0.3.0
 org.gradle.jvmargs=-Xmx4G -Dfile.encoding=UTF-8
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 loom.disableRemappedSources=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip

--- a/src/client/java/com/metalrender/render/MetalWorldRenderer.java
+++ b/src/client/java/com/metalrender/render/MetalWorldRenderer.java
@@ -164,7 +164,7 @@ public class MetalWorldRenderer {
     float yaw = (float)Math.toRadians(camera.getYaw() + 180.0F);
     view.rotateY(-yaw);
     view.rotateX(-pitch);
-    net.minecraft.util.math.Vec3d pos = camera.getPos();
+    net.minecraft.util.math.Vec3d pos = camera.getCameraPos();
     view.translate((float)-pos.x, (float)-pos.y, (float)-pos.z);
     return view;
   }

--- a/src/client/java/com/metalrender/sodium/backend/MeshShaderBackend.java
+++ b/src/client/java/com/metalrender/sodium/backend/MeshShaderBackend.java
@@ -160,7 +160,7 @@ public final class MeshShaderBackend {
       return;
     }
 
-    Vec3d cameraPos = camera.getPos();
+    Vec3d cameraPos = camera.getCameraPos();
     java.util.List<Long> toRemove = new java.util.ArrayList<>();
 
     for (ChunkMesh mesh : this.chunkMeshes.values()) {
@@ -195,7 +195,7 @@ public final class MeshShaderBackend {
       this.lastCleanupFrame = currentFrame;
     }
 
-    Vec3d cameraPos = camera.getPos();
+    Vec3d cameraPos = camera.getCameraPos();
     boolean lodEnabled = MetalRenderConfig.distanceLodEnabled();
     int lodNear = MetalRenderConfig.lodDistanceThreshold();
     int lodFar = MetalRenderConfig.lodFarDistance();

--- a/src/client/java/com/metalrender/sodium/mixins/SodiumRendererMixin.java
+++ b/src/client/java/com/metalrender/sodium/mixins/SodiumRendererMixin.java
@@ -1,6 +1,7 @@
 package com.metalrender.sodium.mixins;
 
 import com.metalrender.MetalRenderClient;
+import net.minecraft.client.gl.GpuSampler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -14,8 +15,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class SodiumRendererMixin {
   @Inject(method = {"drawChunkLayer"}, at = { @At("HEAD") }, require = 0)
   private void metalrender$replaceRender(@Coerce Object viewport,
-                                         @Coerce Object matrices, double x,
-                                         double y, double z, CallbackInfo ci) {
+                                         @Coerce Object matrices,
+                                         double x, double y, double z,
+                                         GpuSampler terrainSampler, CallbackInfo ci) {
     if (MetalRenderClient.isEnabled() &&
         MetalRenderClient.getWorldRenderer() != null) {
       MetalRenderClient.getWorldRenderer().renderFrame(viewport, matrices, x, y,

--- a/src/client/java/com/metalrender/sodium/mixins/sodiumhook/SodiumWorldRendererMixin_CM.java
+++ b/src/client/java/com/metalrender/sodium/mixins/sodiumhook/SodiumWorldRendererMixin_CM.java
@@ -1,5 +1,8 @@
 package com.metalrender.sodium.mixins.sodiumhook;
 
+import net.caffeinemc.mods.sodium.client.render.chunk.ChunkRenderMatrices;
+import net.minecraft.client.gl.GpuSampler;
+import net.minecraft.client.render.BlockRenderLayerGroup;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -19,8 +22,6 @@ public class SodiumWorldRendererMixin_CM {
 
   @Inject(method = {"drawChunkLayer"}, at = { @At("HEAD") }, cancellable = true,
           require = 0)
-  private void metalrender$drawChunkLayer(@Coerce Object terrainPass,
-                                          @Coerce Object matrices, double x,
-                                          double y, double z, CallbackInfo ci) {
+  private void metalrender$drawChunkLayer(BlockRenderLayerGroup group, ChunkRenderMatrices matrices, double x, double y, double z, GpuSampler terrainSampler, CallbackInfo ci) {
   }
 }

--- a/src/client/java/com/metalrender/util/OcclusionCuller.java
+++ b/src/client/java/com/metalrender/util/OcclusionCuller.java
@@ -18,7 +18,7 @@ public class OcclusionCuller {
       this.depthGrid[i] = Float.POSITIVE_INFINITY;
     }
 
-    Vec3d pos = camera.getPos();
+    Vec3d pos = camera.getCameraPos();
     this.camX = pos.x;
     this.camY = pos.y;
     this.camZ = pos.z;


### PR DESCRIPTION
Hi There!

Was interested in getting a 1.21.11 version out because I love and actively use this mod! Seemed to be working based on what I tested. Bobby 256 render distance on an M3 Pro works great!

I noticed that the head of the main branch is currently a WIP, so I based my branch off of the [Updated v0.1.6](https://github.com/webblepebbles/MetalRenderr/commit/85e7a5fbb9ceff79919fb4b3c851fdc3fe49477a) commit.

Also, just a warning that in 1.21.11 net.minecraft.client.gui.widget.ClickableWidget#renderWidget() is marked final, so you might need to use an access widener on the UI changes that are on the head of main (not relevant for this pr). 

Thanks for the hard work! Excited to see the rest of the file optimizations, and also happy to port those changes to 1.21.11 when they are ready.